### PR TITLE
Reconstructed NavBar to be responsive

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "bootstrap": "^4.5.2",
     "emotion-theming": "^10.0.27",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/App.css
+++ b/src/App.css
@@ -9,7 +9,7 @@ body {
   color: #444444;
 }
 
-nav {
+/* nav {
   display: flex;
   background-color: #503d81;
   width: 100%;
@@ -17,7 +17,7 @@ nav {
   padding-left: 0px!important;
   color: #f8f8f8;
   padding-right: 0px!important;
-}
+} */
 
 .content {
   padding: 0.5em;

--- a/src/App.js
+++ b/src/App.js
@@ -7,14 +7,17 @@ import Team from "./components/Team"
 import Contact from "./components/contact"
 function App() {
   const [darkTheme, setDarkTheme] = React.useState(true);
+
+  //Used to toggle the value of darkTheme when the button is pressed.
+  function handleClick() {
+    setDarkTheme(!darkTheme);
+  }
+
   return (
     <div className={darkTheme ? "dark-theme" : "light-theme"}>
-      <nav>
-        <NavBar />
-        <button onClick={() => setDarkTheme((prevTheme) => !prevTheme)}>
-          {darkTheme ? "Light" : "Dark"}
-        </button>
-      </nav>
+
+      {/* Value of darkTheme is passed in order to dynamically change the Button Text */}
+      <NavBar onClick={handleClick} darkTheme={darkTheme}/>
       <div className="app">
         <About />
         <Projects />

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,12 +1,23 @@
 import React from "react";
 import "./style.css";
-function NavBar() {
+import 'bootstrap/dist/css/bootstrap.css';
+
+function NavBar({onClick, darkTheme}) {
   return (
-    <div className="about-container">
-      <span><a href="#about" className="about-text">About</a></span>
-      <span><a href="#projects" className="about-text">Projects</a></span>
-      <span><a href="#team" className="about-text">Team</a></span>
-    </div>
+    <nav class="navbar navbar-expand-lg navbar-dark custom-color">
+      <a class="navbar-brand custom-link" href="#">Codesis</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+        <div class="navbar-nav ml-auto">
+          <a class="nav-link active custom-link" href="#">About <span class="sr-only">(current)</span></a>
+          <a class="nav-link custom-link" href="#">Projects</a>
+          <a class="nav-link custom-link" href="#">Team</a>
+          <button className="btn btn-outline-warning" onClick={onClick}>{darkTheme? 'Light':'Dark'}</button>
+        </div>
+      </div>
+    </nav>
   );
 }
 export default NavBar;

--- a/src/components/style.css
+++ b/src/components/style.css
@@ -59,3 +59,11 @@ a {
 .handle{
   margin-right: 16px;
 }
+
+.custom-color {
+  background-color: #332940;
+}
+
+.custom-link {
+  margin-right: 25px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,6 +2583,11 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bootstrap@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.5.2.tgz#a85c4eda59155f0d71186b6e6ad9b875813779ab"
+  integrity sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
The NavBar was minimally styled in the previous version. Reconstructed to add a Brand name, push links to the right. The components are more structured, with the dark theme state being passed on as props, instead of having a button in the App component. This also attempts to solve issue #16 